### PR TITLE
Implement undo modifier as first argument #11

### DIFF
--- a/docs/useful-links.md
+++ b/docs/useful-links.md
@@ -14,11 +14,6 @@ Useful hints and links for the `ma'shmallow-0` project
   ```
 
 
-## Bash debugging
-
-- excellent article: https://www.shell-tips.com/bash/debug-script/
-
-
 ## Makefile guides
 
 - General tutorials:
@@ -34,9 +29,12 @@ Useful hints and links for the `ma'shmallow-0` project
   - https://stackoverflow.com/questions/4036191
 
 
-## Shell linting
+## Shell (sh/bash)
 
-- Best known: https://github.com/koalaman/shellcheck/
+- Best known linter: https://github.com/koalaman/shellcheck/
+- Good ex. of getopts: https://blog.mafr.de/2007/08/05/cmdline-options-in-shell-scripts/
+- Sh/Bash debugging
+  - excellent article: https://www.shell-tips.com/bash/debug-script/
 
 
 ## git-related

--- a/src/bin/mash
+++ b/src/bin/mash
@@ -6,7 +6,9 @@ _MASH_HOME="${MASH_HOME:-$(dirname "$(dirname "$0")")}"
 # Params:
 
 # Dev variables
-DEBUG=true # use DEBUG=false to suppress debuggin
+
+# Use DEBUG=true to enable debug level messaging. Default is 'false'.
+DEBUG=${DEBUG:-false}
 
 # TODO: Decide if we need include* and move (or remove) these.
 
@@ -39,12 +41,19 @@ DEBUG=true # use DEBUG=false to suppress debuggin
     . "${_LIB_DIR}/libma.sh"
 }
 
+mash_action='doit'  # one of 'doit', 'undo'
+if [ x"${1}" = xundo ]; then
+    mash_action='undo'
+    shift
+fi
+
 verb="${1}"
 recipe="${2}"
 
 script_dir="${_RECIPES_DIR}/${verb}"
 script_full_path="${script_dir}/${recipe}.sh"
 
+log debug "mash_action=${mash_action}"
 log debug "script_dir=${script_dir}"
 log debug "script_full_path=${script_full_path}"
 

--- a/src/lib/libma.sh
+++ b/src/lib/libma.sh
@@ -5,7 +5,6 @@
 _ARCH=x86_64
 _LOCAL="$HOME/.local"
 
-DEBUG=false # use DEBUG=false to suppress debugging
 
 die() {
     rc=$1
@@ -38,7 +37,7 @@ log() {
             echo "I: $msg"
             ;;
         debug*)
-            [ $DEBUG != false ] && echo "DEBUG: $msg" >> /dev/stderr
+            [ x$DEBUG = xtrue ] && echo "DEBUG: $msg" >> /dev/stderr
             ;;
         testfail)
             echo "TEST-FAIL: $msg"

--- a/src/share/recipes/install/bitwarden.sh
+++ b/src/share/recipes/install/bitwarden.sh
@@ -120,4 +120,4 @@ undo() {
     fi
 }
 
-doit
+$mash_action

--- a/src/share/recipes/install/dev-essentials.sh
+++ b/src/share/recipes/install/dev-essentials.sh
@@ -97,4 +97,4 @@ undo() {
     log info "** dev-essentials removal successful."
 }
 
-doit
+$mash_action

--- a/src/share/recipes/install/docker-compose.sh
+++ b/src/share/recipes/install/docker-compose.sh
@@ -1,26 +1,34 @@
 #! /bin/sh
 
-echo x"$(sudo whoami)"
-if [ x"$(sudo whoami)" != xroot ]; then
-  die 15 'FATAL: Not sudo root, terminating'
-fi
+doit() {
+    echo x"$(sudo whoami)"
+    if [ x"$(sudo whoami)" != xroot ]; then
+        die 15 'FATAL: Not sudo root, terminating'
+    fi
 
-if [ x"$HOME" == xroot ]; then
-  die 15 'FATAL: Root but not sudo root, terminating'
-fi
+    if [ x"$HOME" == xroot ]; then
+        die 15 'FATAL: Root but not sudo root, terminating'
+    fi
 
-if curl -V >/dev/null 2>&1; then :; else
-  die 15 'FATAL: curl not found, terminating'
-fi
+    if curl -V > /dev/null 2>&1; then :; else
+        die 15 'FATAL: curl not found, terminating'
+    fi
 
-# TODO: take the latest version automagically
+    # TODO: take the latest version automagically
 
-_ARCH=x86_64
-_LOCAL="$HOME/.local"
-_VERSION='1.27.4'
-_BIN_LOC="$HOME/.local/bin/docker-compose"
-_FILE_URL="https://github.com/docker/compose/releases/download/${_VERSION}/docker-compose-$(uname -s)-$(uname -m)"
+    _ARCH=x86_64
+    _LOCAL="$HOME/.local"
+    _VERSION='1.27.4'
+    _BIN_LOC="$HOME/.local/bin/docker-compose"
+    _FILE_URL="https://github.com/docker/compose/releases/download/${_VERSION}/docker-compose-$(uname -s)-$(uname -m)"
 
-curl -L "${_FILE_URL}" -o "${_BIN_LOC}"
-chmod +x "${_BIN_LOC}"
-docker-compose --version && echo 'Done.' || die 12 'Docker-compose installation FAILED'
+    curl -L "${_FILE_URL}" -o "${_BIN_LOC}"
+    chmod +x "${_BIN_LOC}"
+    docker-compose --version && echo 'Done.' || die 12 'Docker-compose installation FAILED'
+}
+
+undo() {
+    log warn "Undo NOT supported (yet) for '$verb $recipe'"
+}
+
+$mash_action

--- a/src/share/recipes/install/docker.sh
+++ b/src/share/recipes/install/docker.sh
@@ -94,7 +94,7 @@ Cheers! ;)
 EOS
 }
 
-main() {
+doit() {
     if already_has_docker; then
         systemctl restart docker.service
         smoke_test
@@ -109,4 +109,4 @@ main() {
 
 }
 
-main
+$mash_action

--- a/src/share/recipes/install/github-cli.sh
+++ b/src/share/recipes/install/github-cli.sh
@@ -103,4 +103,4 @@ undo() {
     log info 'UNinstallation ended.'
 }
 
-doit
+$mash_action

--- a/src/share/recipes/install/pipx-local.sh
+++ b/src/share/recipes/install/pipx-local.sh
@@ -119,5 +119,4 @@ undo() {
     log info 'UNinstallation ended.'
 }
 
-doit
-#undo
+$mash_action

--- a/src/share/recipes/install/pycharm-community.sh
+++ b/src/share/recipes/install/pycharm-community.sh
@@ -163,4 +163,4 @@ UN-installation ended.
 EOS
 }
 
-doit
+$mash_action

--- a/src/share/recipes/install/pycharm-pro.sh
+++ b/src/share/recipes/install/pycharm-pro.sh
@@ -4,6 +4,8 @@
 
 # Assumming lib/libma.sh has been sourced already.
 
+die 22 "pycharm-pro is deprecated in favour of a universal pycharm recipe."
+
 DEBUG=true  # use DEBUG=false to suppress debugging
 
 

--- a/src/share/recipes/install/vscodium.sh
+++ b/src/share/recipes/install/vscodium.sh
@@ -112,5 +112,4 @@ undo() {
     echo 'Undo install done.'
 }
 
-doit
-# undo
+$mash_action

--- a/src/share/recipes/install/wire.sh
+++ b/src/share/recipes/install/wire.sh
@@ -119,5 +119,4 @@ undo() {
     fi
 }
 
-doit
-#undo
+$mash_action

--- a/src/share/recipes/setup/hello.sh
+++ b/src/share/recipes/setup/hello.sh
@@ -1,4 +1,12 @@
 #! /bin/sh
 # (Helps for experiments.)
 
-echo "Hello, $USER! Mash seems to work ;)"
+doit() {
+    echo "Hello, $USER! 'mash' seems working ;)"
+}
+
+undo() {
+    echo "Farewell, $USER! 'mash undo' seems to work ;)"
+}
+
+${mash_action}

--- a/src/share/recipes/setup/python-dev.sh
+++ b/src/share/recipes/setup/python-dev.sh
@@ -2,14 +2,35 @@
 
 # Assumming lib/libma.sh has been sourced already.
 
+link_path="$_LOCAL/bin/python"
+
+
 set_python_as_link() {
     #: Make binary python available as a link to python3:
     into_dir_do "$_LOCAL/bin" 'ln -s "$(which python3)" python'
+    # TODO: depending on 'which' - not ideal, think on replacement
     log info "Created symlink 'python' to $(which python3)"
 }
 
-skip_msg='python executable found, skipping'
-python -V 2>/dev/null && log info "$skip_msg" || set_python_as_link
+smoke_test() {
+    python -V || die "Creating python as link to python3 FAILED."
+    log info "Smoke test OK. (python -V)"
+}
 
-# smoke test:
-python -V || die "Creating python as link to python3 FAILED."
+doit() {
+    skip_msg="'python' executable found, skip linking."
+    python -V 2>/dev/null && log info "$skip_msg" || set_python_as_link
+    smoke_test
+}
+
+undo() {
+    if ! [ -e "${link_path}" ]; then
+        log warn "Link '~/.local/bin/python' python3 not there, skipping."
+    else
+        log info "Removing '~/.local/bin/python' link to python3..."
+        rm "${link_path}"
+        [ -e "${link_path}" ] && die 14 "Removing ${link_path} FAILED!"
+    fi
+}
+
+$mash_action


### PR DESCRIPTION
## Implement undo modifier as first argument
(Task #11)

 - Modify mash executable to check for $1 and shift args;
 - Replace 'doit' call with $mash_action for all working
   recipes;
 - Refactor python-dev, docker-compose and hello recipes;
 - Set DEBUG to accept external value, false by default.

## Testing
- Tested manually for several recipes - seems to work fine.