### PR TITLE
Resolve project versionng related issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VENV_DIR := .venv
 
 # current build version
 # _version_ := $(shell git tag | tail -1)
-_version_ := $(shell ./scripts/4make/dump-version.sh)
+_version_ := $(shell ./scripts/dump-version.sh)
 
 # current branch
 branch := $(shell git branch --no-color --show-current)
@@ -15,18 +15,19 @@ branch := $(shell git branch --no-color --show-current)
 # Anything in src/ matters for re-creating the dist tarball (but install.sh)
 EXCLUDED := install.sh
 SOURCES := $(shell find ./src/ -name "*" -a ! -name $(EXCLUDED))
+DISTFILE := ./dist/mash-v$(_version_).tgz
 
 
-./dist/mash-$(_version_).tgz:  $(SOURCES)
+$(DISTFILE):  $(SOURCES)
 	@echo "_version_=[$(_version_)]"
 	@[ -n "$(_version_)" ] || { echo 'FATAL: version _version_ NOT found in git _version_ log'; exit 11; }
 	@echo $(_version_) > ./src/etc/version
 	@[ -d ./dist/ ] || mkdir -p ./dist
-	@rm -f ./dist/mash-v$(_version_).tgz
-	@tar czvf ./dist/mash-v$(_version_).tgz -C src --exclude=$(EXCLUDED) .
-	@echo "Created ./dist/mash-v$(_version_).tgz."
+	@rm -f $(DISTFILE)
+	@tar czvf $(DISTFILE) -C src --exclude=$(EXCLUDED) .
+	@echo "Created $(DISTFILE)."
 
-dist:  ./dist/mash-$(_version_).tgz
+dist:  $(DISTFILE)
 
 
 show-sources:

--- a/docs/Release-howto.md
+++ b/docs/Release-howto.md
@@ -8,8 +8,8 @@ Each release version is in the form `major.minor.patch`, for
 example: `1.2.0`.
 
 _Unreleased builds_ are versioned `major.minon.patch-hash` where
-`hash` is a string composed of the first seven characters of the
-git commit sha1 hash. Example: `1.2.0-4c68d15`
+`hash` is a string composed of the first 5 characters of the git
+commit sha1 hash. Example: `1.2.0-4c68d15`
 
 ## Tagging
 

--- a/scripts/4make/show-release.py
+++ b/scripts/4make/show-release.py
@@ -44,12 +44,13 @@ def _main(argv: list) -> int:
 
 
     result = f'''\
- $ # Make sure you have bumped version and committed with a message like:
- $ # Release v{version} - Improved docker-related recipes
+ $ # Make sure you have bumped ./next-tag and committed with a message like:
+ $ # Release v{version} - Improve docker-related recipes
  $ git tag v{version}
  $ make clean-dist && make dist
  $ git push && git push --tags
- $ gh release create v{version} --notes "{release_note} ({commit[:7]}, unofficial)" ./dist/mash-v{version}.tgz
+ $ # The command below creates a DRAFT release - publish after successful CI ;)
+ $ gh release create v{version} -d -t v{version} -n "{release_note} ({commit[:7]}, unofficial)" ./dist/mash-v{version}.tgz
 '''
 
     print(result, end="")

--- a/scripts/dump-version.sh
+++ b/scripts/dump-version.sh
@@ -9,10 +9,10 @@
 # TODO: provide unit and e2e tests
 # TODO: move to ../
 
-version_regex='^.*v\([0-9]\+.[0-9]\+.[0-9]\+\).*$'
 
 extract_from_message() {
     # local message='Release v 1.2.0 here'
+    local version_regex='^.*v\([0-9]\+.[0-9]\+.[0-9]\+\).*$'
     local message="$(git log -n1 --format=format:%s)"
     local version
 
@@ -40,12 +40,14 @@ main() {
 
     tag="$(extract_from_message)"
     if [ -n "$tag" ]; then
-        hash="release-$(truncated_hash)"
+        # hash="-release"
+        hash='' # we n
     else
-        hash="$(truncated_hash)"
+        hash="-$(truncated_hash)"
+        tag="$(cat ./next-tag || cat ../next-tag)"
     fi
 
-    printf '%s-%s\n' "$tag" "$hash"
+    printf '%s%s\n' "$tag" "$hash"
 }
 
 main

--- a/src/bin/mash
+++ b/src/bin/mash
@@ -17,72 +17,81 @@ DEBUG=${DEBUG:-false}
 
 # TODO: move (or remove) include*()
 
-# include() {
-#     lib_script="$1"
-#     # shellcheck disable=SC1090
-#     . "${_LIB_DIR}/${lib_script}"
-# }
-
-# include_recipe() {
-#     verb_n_script="$1"
-#     # shellcheck disable=SC1090
-#     . "${_RECIPES_DIR}/${verb_n_script}"
-# }
-
 # include libma.sh
 
 . "$MASH_HOME/lib/sys.sh"
 
-[ "$DEBUG" = true ] && echo "DEBUG: _MASH_HOME=[$_MASH_HOME]"
-
-if [ "$1" = '-v' ] || [ "$1" = '--version' ]; then
-    IFS=-
-    read -r _version_ _hash_ < "$MASH_HOME/etc/version"
-    echo "ma'shmallow v$_version_ ($_hash_)"
-    exit 0
-fi
-
-if [ "$1" = '-h' ] || [ "$1" = '--help' ]; then
-    echo "ma'shmallow v$_version_: help not (yet) available, apologies... :\\"
-    # TODO: write a help page
-    exit 1
-fi
-
 import mashrc
 import libma
 
-mash_action='doit' # one of 'doit', 'undo', 'verify'
+_mash_project_name_="ma'shmallow"
 
-case "${1}" in
-    install | setup | self)
-        true
-        ;;
+#: Process first argument if -v or --version.
+process_version() {
 
-    undo | verify)
-        mash_action="${1}"
-        shift
-        ;;
-    *)
-        die 5 "Unknown verb or modifier: '$1'"
-        ;;
-esac
+    if [ "$1" = '-v' ] || [ "$1" = '--version' ]; then
+        IFS=-
+        read -r _version_ _hash_ < "$MASH_HOME/etc/version"
+        [ -n "$_hash_" ] || _hash_='release'  # when on a release commit
+        echo "$_mash_project_name_ v$_version_ ($_hash_)"
+        exit 0
+    fi
+}
 
-verb="${1}"
-recipe="${2}"
+#: Process first argument if -h or --help.
+process_help() {
+    if [ "$1" = '-h' ] || [ "$1" = '--help' ]; then
+        echo "$_mash_project_name_ v$_version_: help not (yet) available, apologies... :\\"
+        # TODO: write a help page
+        exit 1
+    fi
 
-script_dir="${_RECIPES_DIR}/${verb}"
-script_full_path="${script_dir}/${recipe}.sh"
+}
 
-log debug "mash_action=${mash_action}"
-log debug "verb=${verb}"
-log debug "recipe=${recipe}"
-log debug "script_dir=${script_dir}"
-log debug "script_full_path=${script_full_path}"
+main() {
+    local _version_
+    local _hash_
 
-[ -e "${script_dir}" ] || die 2 "Unknown verb '${verb}'"
-[ -f "${script_full_path}" ] || die 2 "Unknown recipe '${recipe}'"
 
-# shellcheck disable=SC1090
-. "${script_full_path}"
+    [ "$DEBUG" = true ] && echo "DEBUG: _MASH_HOME=[$_MASH_HOME]"
+    process_version "$@"
+    process_help "$@"
 
-# include_recipe "${verb}/${script}"
+    mash_action='doit' # one of 'doit', 'undo', 'verify'
+
+    case "${1}" in
+        install | setup | self)
+            true
+            ;;
+
+        undo | verify)
+            mash_action="${1}"
+            shift
+            ;;
+        *)
+            die 5 "Unknown verb or modifier: '$1'"
+            ;;
+    esac
+
+    verb="${1}"
+    recipe="${2}"
+
+    script_dir="${_RECIPES_DIR}/${verb}"
+    script_full_path="${script_dir}/${recipe}.sh"
+
+    log debug "mash_action=${mash_action}"
+    log debug "verb=${verb}"
+    log debug "recipe=${recipe}"
+    log debug "script_dir=${script_dir}"
+    log debug "script_full_path=${script_full_path}"
+
+    [ -e "${script_dir}" ] || die 2 "Unknown verb '${verb}'"
+    [ -f "${script_full_path}" ] || die 2 "Unknown recipe '${recipe}'"
+
+    # shellcheck disable=SC1090
+    . "${script_full_path}"
+
+    # include_recipe "${verb}/${script}"
+}
+
+main "$@"


### PR DESCRIPTION
## Resolve project versioning related issues

 - Have `make dist` generate a `mash-v?.?.?.tgz` named archive
   for a final release;
 - Move `dump-version.sh` to `./scripts`;
 - Update and improve the `show-release` target;
 - Update docs and other minor fixes and improvements.

Part of #54