### PR TITLE
Improve sys.sh related code

### DIFF
--- a/src/bin/mash
+++ b/src/bin/mash
@@ -1,25 +1,10 @@
 #! /bin/sh
 
-# [ -n "$MASH_HOME" ] || die 1 "mash NOT configured - MASH_HOME not set (E1211)"
-_MASH_HOME="${MASH_HOME:-$(dirname "$(dirname "$0")")}"
-
-# Params:
-
-# Dev variables
-
-# Use DEBUG=true to enable debug level messaging. Default is 'false'.
-DEBUG=${DEBUG:-false}
-
-# TODO: Decide if we need include* and move (or remove) these.
-
-# alias include='. $MASH_HOME/'
-# alias include_recipe='. $MASH_HOME/share/recipes'
-
-# TODO: move (or remove) include*()
-
-# include libma.sh
+#: Ma'shmallow main executable.
 
 . "$MASH_HOME/lib/sys.sh"
+
+_MASH_HOME="${MASH_HOME:-$(dirname "$_path_")}"
 
 import mashrc
 import logging
@@ -29,7 +14,6 @@ _mash_project_name_="ma'shmallow"
 
 #: Process first argument if -v or --version.
 process_version() {
-
     if [ "$1" = '-v' ] || [ "$1" = '--version' ]; then
         IFS=-
         read -r _version_ _hash_ < "$MASH_HOME/etc/version"
@@ -53,8 +37,7 @@ main() {
     local _version_
     local _hash_
 
-
-    [ "$DEBUG" = true ] && echo "DEBUG: _MASH_HOME=[$_MASH_HOME]"
+    _debug "_MASH_HOME=[$_MASH_HOME]"
     process_version "$@"
     process_help "$@"
 
@@ -80,19 +63,17 @@ main() {
     script_dir="${_RECIPES_DIR}/${verb}"
     script_full_path="${script_dir}/${recipe}.sh"
 
-    _debug "mash_action=${mash_action}"
-    _debug "verb=${verb}"
-    _debug "recipe=${recipe}"
-    _debug "script_dir=${script_dir}"
-    _debug "script_full_path=${script_full_path}"
+    _debug "mash_action=[${mash_action}]"
+    _debug "verb=[${verb}]"
+    _debug "recipe=[${recipe}]"
+    _debug "script_dir=[${script_dir}]"
+    _debug "script_full_path=[${script_full_path}]"
 
     [ -e "${script_dir}" ] || die 2 "Unknown verb '${verb}'"
     [ -f "${script_full_path}" ] || die 2 "Unknown recipe '${recipe}'"
 
     # shellcheck disable=SC1090
     . "${script_full_path}"
-
-    # include_recipe "${verb}/${script}"
 }
 
 main "$@"

--- a/src/bin/runner.sh
+++ b/src/bin/runner.sh
@@ -1,1 +1,0 @@
-../lib/unittest/runner.sh

--- a/src/bin/shtest
+++ b/src/bin/shtest
@@ -1,0 +1,1 @@
+../lib/unittest/shtest

--- a/src/lib/libma.sh
+++ b/src/lib/libma.sh
@@ -7,13 +7,13 @@ _LOCAL="$HOME/.local"
 
 import logging
 
-die() {
-    rc=$1
-    msg="$2"
-
-    echo "FATAL: $msg"
-    exit $rc
-}
+#die() {
+#    rc=$1
+#    msg="$2"
+#
+#    echo "FATAL: $msg"
+#    exit $rc
+#}
 
 #include() {
 #    lib_script="$1"

--- a/src/lib/logging.sh
+++ b/src/lib/logging.sh
@@ -18,40 +18,6 @@ MASH_LOG_LEVEL=${MASH_LOG_LEVEL:-INFO}
 # If DEBUG is set to true - tune the level to DEBUG
 [ "$DEBUG" = true ] && MASH_LOG_LEVEL=DEBUG
 
-#: Color settings for color-enabled terminal
-__logging__set_colors() {
-    C_BOLD='\e[1m'
-    C_OFF='\e[0;00m'
-
-    C_FATAL="${C_BOLD}\e[38;5;196m"
-    C_ERROR='\e[38;5;9m'
-    C_WARN='\e[38;5;3m'
-    C_INFO='\e[38;5;14m'
-    C_SAY='\e[38;5;15m'
-    C_DEBUG='\e[38;5;6m'
-    C_TRACE='\e[38;5;13m'
-}
-
-# shellcheck disable=2034
-__logging__init_color_vars() {
-
-    C_FATAL=
-    C_ERROR=
-    C_WARN=
-    C_INFO=
-    C_SAY=
-    C_DEBUG=
-    C_TRACE=
-    C_BOLD=
-    C_OFF=
-
-    case "$TERM" in
-        *color*)
-            __logging__set_colors
-            ;;
-    esac
-}
-
 # shellcheck disable=2034
 __logging__set_global_vars() {
 
@@ -102,7 +68,7 @@ logging__set_level() {
 
 logging__say() {
     local msg="$1"
-    echo "!! ${C_SAY}$msg${C_OFF}"
+    echo "!! ${C_SAY}${msg}${C_OFF}"
 }
 
 logging__log() {
@@ -130,10 +96,7 @@ logging__log() {
 }
 
 __logging__init() {
-
-    __logging__init_color_vars
     __logging__set_global_vars
-
     logging__set_level "$MASH_LOG_LEVEL"
 
     # shellcheck disable=2139

--- a/src/lib/sys.sh
+++ b/src/lib/sys.sh
@@ -6,133 +6,198 @@
 # listed in MASH_IMPORT_PATH and sourced if found, othewise
 # 'import' exits with a message and rc=5.
 
-# TODO: remove the smoke tests form here and provide tests in a separate module.
-# TODO: clarify who defines MASH_IMPORT_PATH and remove it from here.
+_sys__noop 2> /dev/null && return 0 # guard against multiple sourcing
 
-# By default, MASH_IMPORT_PATH contains ${MASH_HOME}/{etc,lib}
-#MASH_IMPORT_PATH="$HOME/.local/opt/mash/etc:$HOME/.local/opt/mash/lib" # eq. to "$MASH_HOME/lib"
+. "$MASH_HOME/lib/logging.sh"
 
-# for tests:
-#MASH_IMPORT_PATH="/a:/b:/c:$HOME/Work/mashmallow-0/scripts/import-stuff:/etc"
-#MASH_IMPORT_PATH="$HOME/.local/lib:$HOME/Work/mashmallow-0/scripts/import-stuff:/lib"
-
-_sys_name_='sys.sh'
 _name_="$(basename "$0")"
+_path_="$(dirname "$0")"
+_sys_name_='sys.sh'
 
-_SYS__MODEXT='.sh'
+_SYS__IMPORTED_MODULES=':sys:' # Store imported modules here, colon-delimited
+_SYS__MODEXT='.sh'             # default module file extension
 
-#: Terminate execution with given rc and message.
+#: Terminate execution with given message and rc and.
 die() {
     rc=$1
     msg="$2"
 
-    echo "FATAL: $msg" >&2
+    _fatal "$msg" >&2
     exit $rc
+}
+
+#: A noop function used to detect whether sys.sh has already been
+#: sourced.
+_sys__noop() { :; }
+
+#: Color settings for color-enabled terminal
+_sys__set_colors() {
+    C_BOLD='\033[1m'
+    C_OFF='\033[0;00m'
+
+    C_FATAL="\033[38;5;160m"
+    C_ERROR='\033[38;5;9m'
+    C_WARN='\033[38;5;3m'
+    C_INFO='\033[38;5;14m'
+    C_SAY='\033[38;5;15m'
+    C_DEBUG='\033[38;5;6m'
+    C_TRACE='\033[38;5;13m'
+    C_OK='\033[38;5;34m'
+}
+
+#: Color settings for color-enabled terminal
+_sys__clear_colors() {
+    C_BOLD=
+    C_OFF=
+
+    C_FATAL=
+    C_ERROR=
+    C_WARN=
+    C_INFO=
+    C_SAY=
+    C_DEBUG=
+    C_TRACE=
+    C_OK=
+}
+
+# shell check disable=2034
+_sys__init_color_vars() {
+
+    case "$TERM" in
+    *color*)
+        _sys__set_colors
+        ;;
+    *)
+        _sys__clear_colors
+        ;;
+    esac
 }
 
 #: Return true if given `$str` contains a colon, false (rc=1) otherwise.
 _sys__contains_colon() {
-  local str="$1"
+    local str="$1"
 
-  case "$str" in
-  *:*)
-    return 0
-    ;;
-  *)
+    case "$str" in
+    *:*)
+        return 0
+        ;;
+    esac
     return 1
-    ;;
-  esac
 }
 
 #: Check if $mod_name (defined in `import()`) or $mod_name${MODEXT}
 #: exists in given `$path` and if so -- source it and return true,
 #: otherwise return false (rc=1).
 _sys__process_path() {
-  local path="$1"
-  local full_path="${path}/${mod_name}"
-  local full_path_ext="${path}/${mod_name}${_SYS__MODEXT}"
+    local path="$1"
+    local mod_name="$2"
+    _debug "_sys__process_path: path=[$path]  mod_name=[$mod_name]"
 
-  # printf 'full_path=[%s]\n' "$full_path"
-  if [ -e "$full_path_ext" ]; then
-    . "$full_path_ext" || exit 6  # TODO: add die() and use it here
-    printf '%s SOURCED.\n' "${mod_name}"
-    return 0
+    local full_path="${path}/${mod_name}"
+    local full_path_ext="${path}/${mod_name}${_SYS__MODEXT}"
 
-  elif [ -e "$full_path" ]; then
-    . "$full_path" || exit 6  # TODO: and here
-    printf '%s SOURCED.\n' "${mod_name}"
-    return 0
+    # printf 'full_path=[%s]\n' "$full_path"
+    if [ -e "$full_path_ext" ]; then
+        . "$full_path_ext" || die 6 "Sourcing FAILED (1:rc=$?) for [$full_path_ext]"
+        _debug "_sys__process_path: $mod_name SOURCED."
+        return 0
 
-  else
-    # printf 'hey, %s not found here.\n' "${mod_filename}"
-    return 1
-  fi
+    elif [ -e "$full_path" ]; then
+        . "$full_path" || die 6 "Sourcing FAILED (2:rc=$?) for [$full_path]"
+        # [ "$DEBUG" = true ] && printf '%s SOURCED.\n' "${mod_name}"
+        _debug "_sys__process_path: $mod_name SOURCED."
+        return 0
+
+    else
+        # printf 'hey, %s not found here.\n' "${mod_filename}"
+        return 1
+    fi
 }
 
 #: Look up module `$mod_filename` (defined in `import()`) in all paths
 #: of given colon-delimited `$path_list`. If found -- source that module
 #: and return true, otherwise return false (rc=1).
 _sys__find_module_in_paths() {
-  local path_list="$1"
-  local IFS_OLD
-  local rc=1 # not found (until proven otherwise)
+    local path_list="$1"
+    local mod_name="$2"
 
-  IFS_OLD="$IFS"
-  IFS=':'
+    local IFS_OLD
+    local rc=1 # not found (until proven otherwise)
 
-  while _sys__contains_colon "$path_list"; do
-    read -r path path_list <<EOF
+    IFS_OLD="$IFS"
+    IFS=':'
+
+    while _sys__contains_colon "$path_list"; do
+        read -r path path_list << EOF
 $path_list
 EOF
-    _sys__process_path "$path" && {
-      rc=0 # found!
-      break
+        _sys__process_path "$path" "$mod_name" && {
+            rc=0 # found!
+            break
+        }
+    done
+
+    [ -n "$path_list" ] && {
+        _sys__process_path "$path_list" "$mod_name" && rc=0 # found!
     }
-  done
 
-  [ -n "$path_list" ] && _sys__process_path "$path_list" && rc=0 # found!
+    IFS="$IFS_OLD"
+    return $rc
+}
 
-  IFS="$IFS_OLD"
-  return $rc
+#: Return true if module has been imported already; false otherwise.
+_sys__module_already_imported() {
+    local mod_name="$1"
+
+    case "$_SYS__IMPORTED_MODULES" in
+    *:"$mod_name":*)
+        return 0
+        ;;
+    *)
+        return 1
+        ;;
+    esac
 }
 
 #: Looks up for a shell module in MASH_IMPORT_PATH and sources it, if found,
 #: otherwise prints an error message and exits rc=5. (See the sys.sh header
 #: comment for more details.)
 import() {
-  local mod_name="$1"
-  # local mod_filename="${mod_name}${_SYS__MODEXT}"
+    local mod_name="$1"
+    # local mod_filename="${mod_name}${_SYS__MODEXT}"
+    [ -n "$mod_name" ] || die 31 "IMPORT ERROR: empty module name: [$mod_name]"
 
-  _sys__find_module_in_paths "$MASH_IMPORT_PATH" || {
-    echo "FATAL: Module $mod_name NOT found in MASH_IMPORT_PATH" >&2
-    echo "       MASH_IMPORT_PATH='$MASH_IMPORT_PATH'"           >&2
-    exit 5
-  }
+    if _sys__module_already_imported "$mod_name"; then
+        _debug "import: Module ALREADY imported: [$mod_name]"
+        return 0
+    fi
+
+    if _sys__find_module_in_paths "$MASH_IMPORT_PATH" "$mod_name"; then
+        _SYS__IMPORTED_MODULES=":$mod_name:$_SYS__IMPORTED_MODULES"
+        _debug "import: _SYS_IMPORTED_MODULES=[$_SYS__IMPORTED_MODULES]"
+
+    else
+        # shellcheck disable=2059
+        {
+            printf "${C_ERROR}IMPORT ERROR: Module ${C_OFF}${C_BOLD}'$mod_name'${C_OFF} ${C_ERROR}"
+            printf "NOT found in MASH_IMPORT_PATH${C_OFF}\n"
+            printf "MASH_IMPORT_PATH='$MASH_IMPORT_PATH'\n"
+        }
+        exit 5
+    fi
 }
 
-test_e2e_case_1() {
-  local path_list='ID:SOME text here: :with possible : INSIDE'
-  printf 'path_list=[%s]\n' "$path_list"
-  _sys__find_module_in_paths "$path_list"
-  echo "DONE."
+#: Initialize the sys module.
+_sys__init() {
+    _sys__init_color_vars
+    [ -z "$_SYS__IMPORTED_MODULES" ] && _SYS__IMPORTED_MODULES=':sys:'
+    _debug "_sys_: _name_=[$_name_] _sys_name_=[$_sys_name_]"
 }
 
-test_e2e_case_2() {
-  import foorc
-  import pathlib
-  echo "FOO=${FOO} and _get_name_($0) returns [$(_get_name_ "$0")]."
-}
-
-test() {
-  test_e2e_case_2
-}
-
+# main:
 if [ "$_name_" = "$_sys_name_" ]; then
-  if [ "$1" = test ]; then
-    test
-  else
-    echo "$_sys_name_ is a library - not callable directly."
-    echo "If you want to run the tests -- use 'test' argument."
+    _error "$_sys_name_ is a library - not callable directly."
     exit 1
-  fi
+else
+    _sys__init
 fi

--- a/src/lib/tests/test-data/bar.sh
+++ b/src/lib/tests/test-data/bar.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+bar_sh_func() {
+    printf '%s' 'bar_sh_func() called'
+}

--- a/src/lib/tests/test-data/foo-pkg/foo-pkg-bar.sh
+++ b/src/lib/tests/test-data/foo-pkg/foo-pkg-bar.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+foo_pkg_bar_sh_func() {
+    printf '%s' 'foo_pkg_bar_sh_func() called'
+}

--- a/src/lib/tests/test-data/foo-pkg/foo-pkg-bazzrc
+++ b/src/lib/tests/test-data/foo-pkg/foo-pkg-bazzrc
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+foo_pkg_bazzrc_func() {
+    printf '%s' 'foo_pkg_bazzrc_func() called'
+}

--- a/src/lib/tests/test-data/foorc
+++ b/src/lib/tests/test-data/foorc
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+foorc_func() {
+    printf '%s' 'foorc_func() called'
+}

--- a/src/lib/tests/test-data/logging-sample.output
+++ b/src/lib/tests/test-data/logging-sample.output
@@ -6,13 +6,13 @@ _debug='logging__log 10'
 _fatal='logging__log 50'
 _say='logging__say'
 --- Running logging_all_levels()...
-[1m[38;5;196mFATAL[0;00m: [1m[38;5;196mThis is a FATAL level message ;)[0;00m
+[38;5;160mFATAL[0;00m: [38;5;160mThis is a FATAL level message ;)[0;00m
 [38;5;9mE[0;00m: [38;5;9mThis is an ERROR level message ;)[0;00m
 [38;5;3mW[0;00m: [38;5;3mThis is a WARN level message ;)[0;00m
 [38;5;14mI[0;00m: [38;5;14mThis is an INFO level message ;)[0;00m
 !! [38;5;15mThis is a SAY message that appears only on console.[0;00m
 [38;5;6mD[0;00m: [38;5;6mThis is a DEBUG level message ;)[0;00m
 --- Running test-logging#logging_level_error()...
-[1m[38;5;196mFATAL[0;00m: test-logging#logging_level_error: [1m[38;5;196mThis is a FATAL level message ;)[0;00m
+[38;5;160mFATAL[0;00m: test-logging#logging_level_error: [38;5;160mThis is a FATAL level message ;)[0;00m
 [38;5;9mE[0;00m: test-logging#logging_level_error: [38;5;9mThis is an ERROR level message ;)[0;00m
 !! [38;5;15mThis is a SAY message that appears only on console.[0;00m

--- a/src/lib/tests/test-gh-download.sh
+++ b/src/lib/tests/test-gh-download.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-. "$MASH_HOME/lib/sys.sh"
+#. "$MASH_HOME/lib/sys.sh"
 
 import mashrc
 import unittest/assert
@@ -22,7 +22,7 @@ test_gh_latest_version() {
 }
 
 test_gh_latest_version_vscodium() {
-    assert_equal "$(gh_latest_version 'VSCodium/vscodium')" '1.61.1'
+    assert_equal "$(gh_latest_version 'VSCodium/vscodium')" '1.61.2'
 }
 
 test_gh_download() {

--- a/src/lib/tests/test-logging.sh
+++ b/src/lib/tests/test-logging.sh
@@ -14,13 +14,13 @@
 #:   (b) run this test suite -- it will (re)create the temp file;
 #:   (c) examine the contents of `$__LOGGING__TMP_FILE`;
 #:   (d) copy the `$__LOGGING__TMP_FILE` into `$__LOGGING__SAMPLE_FILE`, e.g.:
-#:       $ cp -p /tmp/logging-test.output src/lib/tests/logging-sample.output
+#:       $ cp -p /tmp/logging-test.output src/lib/tests/test-data/logging-sample.output
 #:   (e) restore the temp file deletion in `teardown_mod()`.
 
 import unittest/assert
 import logging
 
-__LOGGING__SAMPLE_FILE='src/lib/tests/logging-sample.output'
+__LOGGING__SAMPLE_FILE='src/lib/tests/test-data/logging-sample.output'
 __LOGGING__TMP_FILE='/tmp/logging-test.output'
 
 show_aliases() {
@@ -81,8 +81,8 @@ setup_mod() {
 teardown_mod() {
     # Suppress to keep the $__LOGGING__TMP_FILE for copying to the reference
     # file $__LOGGING__SAMPLE_FILE. (Use a noop like ':' or 'true'.)
-    rm -f "$__LOGGING__TMP_FILE"
-    #:
+#    rm -f "$__LOGGING__TMP_FILE"
+    :
 }
 
 test_logging_unknown_level() {

--- a/src/lib/tests/test-os.sh
+++ b/src/lib/tests/test-os.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-. "$MASH_HOME/lib/sys.sh"
+#. "$MASH_HOME/lib/sys.sh"
 
 import mashrc
 import unittest/assert

--- a/src/lib/tests/test-sys-enduse.sh
+++ b/src/lib/tests/test-sys-enduse.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+#: End-user level tests for `sys.sh`.
+
+# import sys by sys ... but hey, this shows explicitly
+# what is under test ;)
+import sys
+import unittest/assert
+
+setup_mod() {
+    _MASH_IMPORT_PATH_OLD="$MASH_IMPORT_PATH"
+    __test_dir=
+}
+
+teardown_mod() {
+    MASH_IMPORT_PATH="$_MASH_IMPORT_PATH_OLD"
+    unset _MASH_IMPORT_PATH_OLD
+    unset __test_dir
+}
+
+setup() {
+    __test_dir="$(dirname "$_mod_path_")"
+}
+
+test_enduse_case_1() {
+    MASH_IMPORT_PATH="$__test_dir/test-data:$__test_dir"
+    import foorc
+    import bar
+    import foo-pkg/foo-pkg-bar
+    import foo-pkg/foo-pkg-bazzrc
+    import bar
+    import foorc
+    import foo-pkg/foo-pkg-bar
+
+    assert_equal 'bar_sh_func() called' "$(bar_sh_func)"
+    assert_equal 'foorc_func() called' "$(foorc_func)"
+    assert_equal 'foo_pkg_bar_sh_func() called' "$(foo_pkg_bar_sh_func)"
+    assert_equal 'foo_pkg_bazzrc_func() called' "$(foo_pkg_bazzrc_func)"
+}

--- a/src/lib/tests/test-sys.sh
+++ b/src/lib/tests/test-sys.sh
@@ -1,0 +1,119 @@
+#! /bin/sh
+
+#: Unit tests for `sys.sh` module
+
+# import sys by sys ... but hey, this shows explicitly
+# what is under test ;)
+import sys
+import unittest/assert
+
+setup_mod() {
+    _MASH_IMPORT_PATH_OLD="$MASH_IMPORT_PATH"
+    __modules_path=
+    __test_dir=
+}
+
+teardown_mod() {
+    MASH_IMPORT_PATH="$_MASH_IMPORT_PATH_OLD"
+    unset _MASH_IMPORT_PATH_OLD
+    unset __modules_path
+    unset __test_dir
+}
+
+setup() {
+    __modules_path="$(dirname "$_mod_path_")/test-data"
+    __test_dir="$(dirname "$_mod_path_")"
+}
+
+test__sys__contains_colon__positive() {
+    assert_true _sys__contains_colon 'whop:'
+    assert_true _sys__contains_colon ':whop'
+    assert_true _sys__contains_colon 'w:w'
+    assert_true _sys__contains_colon ':'
+    assert_true _sys__contains_colon ' : '
+}
+
+test__sys__contains_colon__negative() {
+    assert_false _sys__contains_colon ''
+    assert_false _sys__contains_colon ';'
+    assert_false _sys__contains_colon 'whop'
+    assert_false _sys__contains_colon '   '
+}
+
+test_die__check_rc() {
+    (die 123 "Some message" > /dev/null 2>&1)
+    assert_equal 123 $?
+}
+
+test_die__check_message() {
+    local _LOG_FORMAT_TIME_CONSOLE_SAVED="$_LOG_FORMAT_TIME_CONSOLE"
+    _LOG_FORMAT_TIME_CONSOLE=
+    local stderr_output
+    _sys__clear_colors
+    stderr_output="$( (die 123 "dying message") 2>&1)"
+    assert_equal 'FATAL: dying message' "$stderr_output"
+    _sys__set_colors
+    _LOG_FORMAT_TIME_CONSOLE="$_LOG_FORMAT_TIME_CONSOLE_SAVED"
+}
+
+test__sys__process_path__found_case_1() {
+    assert_true _sys__process_path "$__modules_path" 'bar'
+    assert_equal 'bar_sh_func() called' "$(bar_sh_func)"
+}
+
+test__sys__process_path__found_case_2() {
+    assert_true _sys__process_path "$__modules_path" 'foorc'
+    assert_equal 'foorc_func() called' "$(foorc_func)"
+}
+
+test__sys__process_path__found_case_3() {
+    assert_true _sys__process_path "$__modules_path" 'foo-pkg/foo-pkg-bar'
+    assert_equal 'foo_pkg_bar_sh_func() called' "$(foo_pkg_bar_sh_func)"
+}
+
+test__sys__process_path__found_case_4() {
+    assert_true _sys__process_path "$__modules_path" 'foo-pkg/foo-pkg-bazzrc'
+    assert_equal 'foo_pkg_bazzrc_func() called' "$(foo_pkg_bazzrc_func)"
+}
+
+test__sys__process_path__found_case_4() {
+    assert_true _sys__process_path "$__modules_path" 'foo-pkg/foo-pkg-bazzrc'
+    assert_equal 'foo_pkg_bazzrc_func() called' "$(foo_pkg_bazzrc_func)"
+}
+
+test__sys__process_path__not_found_case_1() {
+    assert_false _sys__process_path "$__modules_path" 'foo-pkg/nonexistent'
+}
+
+test__sys__process_path__not_found_case_2() {
+    assert_false _sys__process_path "$__modules_path" 'nonexistent'
+}
+
+test__sys__find_module_in_paths__found() {
+    local mash_path="$__test_dir/test-data:$__test_dir"
+    assert_true _sys__find_module_in_paths "$mash_path" bar
+    assert_true _sys__find_module_in_paths "$mash_path" bar.sh # works as well
+    assert_true _sys__find_module_in_paths "$mash_path" foo-pkg/foo-pkg-bar
+}
+
+test__sys__find_module_in_paths__not_found() {
+    local mash_path="$__test_dir/test-data:$__test_dir"
+    assert_false _sys__find_module_in_paths "$mash_path" nonexistent
+}
+
+test__sys__module_already_imported__standard_case() {
+    local _SYS__IMPORTED_MODULES_SAVED="$_SYS__IMPORTED_MODULES"
+    _SYS__IMPORTED_MODULES=':one:two:'
+    assert_true _sys__module_already_imported one
+    assert_true _sys__module_already_imported two
+    assert_false _sys__module_already_imported three
+    _SYS__IMPORTED_MODULES="$_SYS__IMPORTED_MODULES_SAVED"
+}
+
+test__sys__module_already_imported__corner_case() {
+    local _SYS__IMPORTED_MODULES_SAVED="$_SYS__IMPORTED_MODULES"
+    _SYS__IMPORTED_MODULES=':'
+    assert_false _sys__module_already_imported ''
+    assert_false _sys__module_already_imported any
+    _SYS__IMPORTED_MODULES="$_SYS__IMPORTED_MODULES_SAVED"
+}

--- a/src/lib/unittest/assert.sh
+++ b/src/lib/unittest/assert.sh
@@ -22,14 +22,20 @@ is_num() {
 }
 
 # shellcheck disable=2120
+#print_pass() {
+#    passmsg="${1:-passed}"
+#    printf 'ok %u - %s: %s\n' $no $_curr_test_ "$passmsg"
+#}
 print_pass() {
-    passmsg="${1:-passed}"
-    printf 'ok %u - %s: %s\n' $no $_curr_test_ "$passmsg"
+    passmsg="${1:-pass}"
+    # printf 'ok %u - %s: %s\n' $no $_curr_test_ "${C_OK}${passmsg}${C_OFF}"
+    echo "ok $no - $_curr_test_: ${C_OK}${passmsg}${C_OFF}"
 }
 
 print_fail() {
     failmsg="$1"
-    printf 'not ok %u - %s: %s\n' $no $_curr_test_ "$failmsg"
+    # printf 'not ok %u - %s: %s\n' $no $_curr_test_ "$failmsg"
+    echo "not ok $no - ${C_ERROR}$_curr_test_: ${failmsg}${C_OFF}"
 
     # _curr_test_rc_ is local for the test runner and reflects any failed checks
     _curr_test_rc_=$(expr $_curr_test_rc +  1)
@@ -37,8 +43,11 @@ print_fail() {
 
 print_error() {
     failmsg="$1"
-    # out=${2:-/dev/stderr}
-    printf '%s: %s\n' $_curr_test_ "$failmsg" >&2
+    # printf '%s: %s\n' $_curr_test_ "$failmsg" >&2
+    echo "${C_ERROR}${_curr_test_}: ${failmsg}${C_OFF}" >&2
+
+    # _curr_test_rc_ is local for the test runner and reflects any failed checks
+    _curr_test_rc_=$(expr $_curr_test_rc +  1)
 }
 
 check_arg_is_num() {

--- a/src/lib/unittest/shtest
+++ b/src/lib/unittest/shtest
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /bin/sh
 
 #: Test modules runner
 #: Parse a test module collecting `test_*` methods, also `setup_mod`,
@@ -7,50 +7,52 @@
 
 . "$MASH_HOME/lib/sys.sh"
 
-_name_="$(basename "$0")"
-_rnr_name_='runner.sh'
+_sht_name_='shtest'
 
 # shellcheck disable=2120
 print_pass() {
     passmsg="${1:-passed}"
-    printf 'ok %u - %s: %s\n' $no $_curr_test_ "$passmsg"
+    printf 'ok %u - %s: %s\n' $no $_curr_test_ "${C_OK}${passmsg}${C_OFF}"
 }
 
 parse_module() {
-    filename="$1"
+    local filename="$1"
+    local IFS_OLD="$IFS"
+    IFS=''
 
-    while IFS='' read -r line; do
+    while read -r line; do
         # TODO: use 'import string' when ready, for stripping lines
 
         case $line in
-            test_*\(*\)*\{)
-                # printf 'TEST METHOD: %s\n' "${line%(*}"
-                test_methods="$test_methods ${line%(*}"
-                ;;
+        test_*\(*\)*\{)
+            # printf 'TEST METHOD: %s\n' "${line%(*}"
+            test_methods="$test_methods ${line%(*}"
+            ;;
 
-            setup_mod\(*\)*\{)
-                # printf 'SETUP MOD METHOD: %s\n' "${line%(*}"
-                setup_mod_name="${line%(*}"
-                ;;
+        setup_mod\(*\)*\{)
+            # printf 'SETUP MOD METHOD: %s\n' "${line%(*}"
+            setup_mod_name="${line%(*}"
+            ;;
 
-            teardown_mod\(*\)*\{)
-                # printf 'TEARDOWN MOD METHOD: %s\n' "${line%(*}"
-                teardown_mod_name="${line%(*}"
-                ;;
+        teardown_mod\(*\)*\{)
+            # printf 'TEARDOWN MOD METHOD: %s\n' "${line%(*}"
+            teardown_mod_name="${line%(*}"
+            ;;
 
-            setup\(*\)*\{)
-                # printf 'SETUP METHOD: %s\n' "${line%(*}"
-                setup_name="${line%(*}"
-                ;;
+        setup\(*\)*\{)
+            # printf 'SETUP METHOD: %s\n' "${line%(*}"
+            setup_name="${line%(*}"
+            ;;
 
-            teardown\(*\)*\{)
-                # printf 'TEARDOWN METHOD: %s\n' "${line%(*}"
-                teardown_name="${line%(*}"
-                ;;
+        teardown\(*\)*\{)
+            # printf 'TEARDOWN METHOD: %s\n' "${line%(*}"
+            teardown_name="${line%(*}"
+            ;;
 
         esac
 
     done < "$filename"
+    IFS="$IFS_OLD"
 }
 
 run() {
@@ -62,11 +64,12 @@ run() {
     local test_methods=
 
     local _curr_test_=
-    local _curr_test_rc_=0
+    local _mod_path_=
+    local _curr_test_rc_
 
-    parse_module "$1"
-
-    . "$1"
+    _mod_path_="$1"
+    parse_module "$_mod_path_"
+    . "$_mod_path_"
 
     [ -n "$setup_mod_name" ] && $setup_mod_name
 
@@ -79,7 +82,9 @@ run() {
         _curr_test_=$method
         _curr_test_rc_=0
         no=$(expr $no + 1)
+
         $method
+
         [ "$_curr_test_rc_" -eq 0 ] && print_pass
 
         [ -n "$teardown_name" ] && $teardown_name
@@ -115,18 +120,22 @@ collect() {
         [ -e "$filename" ] || die 33 "Path NOT found: $filename"
 
         case "$(basename "$filename")" in
-            test-*.sh | test_*.sh)
-                test_modules="$test_modules:$filename"
-                ;;
+        test-*.sh | test_*.sh)
+            test_modules="$test_modules:$filename"
+            ;;
         esac
     }
 
-    scan_direcroty() {
+    scan_directory() {
         path="$1"
-        printf '(2) scan_direcroty %s\n' "$path"
+        printf '(2) scan_directory %s\n' "$path"
+
+        # guard against breaking on no glob match below for empty directories
+        [ -z "$(ls $path/* 2> /dev/null)" ] && return 0
+
         for entry in $path/*; do
             if [ -d "$entry" ]; then
-                scan_direcroty "$entry"
+                scan_directory "$entry"
             else
                 collect_if_name_matches "$entry"
             fi
@@ -137,34 +146,34 @@ collect() {
 
         printf '(1) path=%s\n' "$path"
         if [ -d "$path" ]; then
-            scan_direcroty "$path"
+            scan_directory "$path"
         else
             collect_if_name_matches "$path"
         fi
     done
     printf 'COLLECTED: %s\n' "$test_modules"
-    # exit 0
 }
 
 main() {
     local test_modules
 
     case "$1" in
-        --help | -help | help | -h)
-            cat << EOS
+    --help | -help | help | -h)
+        cat << EOS
 Unit test runner v 0.0.0 ;)
 USAGE:
   $ $(basename "$0") PATH-to-TEST-ENTRY [PATH-to-TEST-ENTRY ...]
 
 EOS
-            exit 0
-            ;;
+        exit 0
+        ;;
     esac
 
     collect "$@"
     run_many
 }
 
-if [ "$_name_" = "$_rnr_name_" ]; then
+_debug "_name_=[$_name_]  _sht_name_=[$_sht_name_]"
+if [ "$_name_" = "$_sht_name_" ]; then
     main "$@"
 fi

--- a/test/e2e/smoke-e2e.sh
+++ b/test/e2e/smoke-e2e.sh
@@ -38,7 +38,7 @@ testrun() {
 }
 
 full_test() {
-    moderate_test
+    standard_test
     testrun install dev-essentials
     testrun install docker
     #testrun install firefox
@@ -91,11 +91,17 @@ main() {
     mod_global=doit
     ${target_func}
 
+    mod_global=doit
+    ${target_func}
+
     mod_global=undo
     $target_func
 
     mod_global=doit
     ${target_func}
+
+    mod_global=undo
+    $target_func
 
     recap
 }


### PR DESCRIPTION
## Improve `sys.sh` related code:

- upgrade `sys.sh` to NOT re-source if already sourced;
- extract tests from `sys.sh` into separate test modues;
- extend `sys.sh` tests;
- make `lib SOURCED` messages to show for DEBUG-level only;
- rename `runner.sh` -> `shtest`;
- upgrade `sys.sh` import to NOT re-source already sourced libraries;
- move color setup in `sys.sh`;
- improve `assert.sh` color-wise;
- improve `install.sh`.


Task: #60