### PR TITLE
Improve error handling

### DIFF
--- a/src/bin/mash
+++ b/src/bin/mash
@@ -74,6 +74,7 @@ main() {
     [ -e "${script_dir}" ] || die 2 "Unknown verb '${verb}'"
     [ -f "${script_full_path}" ] || die 2 "Unknown recipe '${recipe}'"
 
+    set -e # exit immediately if a command exits with a non-zero status
     # shellcheck disable=SC1090
     . "${script_full_path}"
 }

--- a/src/install.sh
+++ b/src/install.sh
@@ -14,7 +14,7 @@ _DOWNLOAD_CACHE=/tmp
 
 _URL_LATEST=https://github.com/ya55en/mashmallow-0/releases/latest
 _URL_DOWNLOAD_RE='^location: https://github.com/ya55en/mashmallow-0/releases/tag/v\(.*\)$'
-__latest__=$(curl -Is $_URL_LATEST | grep ^location | tr -d '\n\r' | sed "s|$_URL_DOWNLOAD_RE|\1|")
+__latest__=$(curl -ISs $_URL_LATEST | grep ^location | tr -d '\n\r' | sed "s|$_URL_DOWNLOAD_RE|\1|")
 __version__="${1:-$__latest__}" # version passed as an argument for unreleased builds
 
 _MASH_FILENAME="mash-v${__version__}.tgz"
@@ -68,7 +68,7 @@ download_mash_core() {
         echo "Release file already downloaded, skipping."
     else
         echo "Downloading ${target_file_path}..."
-        curl -sL "$_URL_DOWNLOAD" -o "${target_file_path}" ||
+        curl -sSL "$_URL_DOWNLOAD" -o "${target_file_path}" ||
             die 9 "Download failed. (URL: $_URL_DOWNLOAD)"
     fi
 }

--- a/src/lib/gh-download.sh
+++ b/src/lib/gh-download.sh
@@ -22,7 +22,7 @@ gh_latest_raw_version() {
     _debug "gh_latest_raw_version(): url_download_re=[$url_download_re]" >&2
 
     local raw_version
-    raw_version=$(curl -Is "$url_latest" | grep ^location | tr -d '\n\r' | sed "s|$url_download_re|\1|")
+    raw_version=$(curl -ISs "$url_latest" | grep ^location | tr -d '\n\r' | sed "s|$url_download_re|\1|")
     printf '%s' "$raw_version"
 }
 
@@ -51,7 +51,7 @@ gh_download() {
         _warn "File already downloaded ($download_target), skipping."
     else
         mkdir -p "${_DOWNLOAD_CACHE}"
-        curl -sL "$download_url" -o "${download_target}" || {
+        curl -sSL "$download_url" -o "${download_target}" || {
             _error "${project_path} download FAILED! (rc=$?)"
         }
     fi

--- a/src/share/recipes/install/font-jetbrains-mono.sh
+++ b/src/share/recipes/install/font-jetbrains-mono.sh
@@ -17,7 +17,7 @@ download_into_cache() {
         _warn "Archive already downloaded, skipping ($_DOWNLOAD_CACHE/$_jbm__filename)"
     else
         _info "Downloading $_jbm__filename..."
-        curl -sL "$_jbm__download_link" -o "$_DOWNLOAD_CACHE/$_jbm__filename" || {
+        curl -sSL "$_jbm__download_link" -o "$_DOWNLOAD_CACHE/$_jbm__filename" || {
             _die 33 "$_jbm__filename download FAILED! (rc=$?)"
         }
         _debug "Downloaded URL: [$_jbm__download_link]"

--- a/src/share/recipes/install/pycharm-community.sh
+++ b/src/share/recipes/install/pycharm-community.sh
@@ -31,7 +31,7 @@ download_tarball() {
         _debug "_DOWNLOAD_CACHE=$_DOWNLOAD_CACHE"
         _info "Downloading Pycharm ${flavor} edition, v${version}..."
         rm -f "${_DOWNLOAD_CACHE}/${pycharm_filename}"
-        curl -sL "$_URL_DOWNLOAD" -o "${_DOWNLOAD_CACHE}/${pycharm_filename}" ||
+        curl -sSL "$_URL_DOWNLOAD" -o "${_DOWNLOAD_CACHE}/${pycharm_filename}" ||
             die 9 "Download failed. (URL: $_URL_DOWNLOAD)"
     fi
 }

--- a/src/share/recipes/install/pycharm-pro.sh
+++ b/src/share/recipes/install/pycharm-pro.sh
@@ -25,7 +25,7 @@ _debug "_URL_DOWNLOAD=[$_URL_HASHSUM]"
 
 # Download and install:
 _info "Downloading Pycharm Pro v${version}..."
-curl -sL "$_URL_DOWNLOAD" -o "/tmp/${pycharm_filename}"
+curl -sSL "$_URL_DOWNLOAD" -o "/tmp/${pycharm_filename}"
 
 # TODO: check sha256 from $_URL_HASHSUM
 

--- a/src/share/recipes/install/slack.sh
+++ b/src/share/recipes/install/slack.sh
@@ -29,7 +29,7 @@ download_deb_file() {
             die 33 "Could NOT create download directory! ($_DOWNLOAD_CACHE)"
         }
         _debug "Downloading [$_slk__download_url]..."
-        curl -sL "$_slk__download_url" -o "$_DOWNLOAD_CACHE/$_slk__filename" || {
+        curl -sSL "$_slk__download_url" -o "$_DOWNLOAD_CACHE/$_slk__filename" || {
             die 33 "$_slk__filename download FAILED! (rc=$?)"
         }
         [ -e "$_DOWNLOAD_CACHE/$_slk__filename" ] || {

--- a/src/share/recipes/install/wire.sh
+++ b/src/share/recipes/install/wire.sh
@@ -19,7 +19,7 @@ download_appimage() {
         _warn "App file already downloaded/cached, skipping."
     else
         _info "Downloading Wire desktop v${version}..."
-        curl -sL "$_URL_DOWNLOAD" -o "${download_target}"
+        curl -sSL "$_URL_DOWNLOAD" -o "${download_target}"
     fi
 }
 

--- a/src/share/recipes/self/upgrade.sh
+++ b/src/share/recipes/self/upgrade.sh
@@ -15,7 +15,7 @@ curr_version=${V#*v}
 
 _URL_LATEST=https://github.com/ya55en/mashmallow-0/releases/latest
 _URL_DOWNLOAD_RE='^location: https://github.com/ya55en/mashmallow-0/releases/tag/v\(.*\)$'
-latest_version=$(curl -Is $_URL_LATEST | grep ^location | tr -d '\n\r' | sed "s|$_URL_DOWNLOAD_RE|\1|")
+latest_version=$(curl -ISs $_URL_LATEST | grep ^location | tr -d '\n\r' | sed "s|$_URL_DOWNLOAD_RE|\1|")
 
 _DOWNLOAD_CACHE=/tmp
 _INSTALL_FILENAME="install.sh"
@@ -47,7 +47,7 @@ download_update() {
     else
         _info "Downloading ${target_file_path}..."
     fi
-    curl -sL "$_URL_DOWNLOAD" -o "${target_file_path}" ||
+    curl -sSL "$_URL_DOWNLOAD" -o "${target_file_path}" ||
         die 9 "Download failed. (URL: $_URL_DOWNLOAD)"
     chmod 764 "${_DOWNLOAD_CACHE}/${_INSTALL_FILENAME}"
 }

--- a/src/share/recipes/setup/fail.sh
+++ b/src/share/recipes/setup/fail.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+# (For testing error handling.)
+
+return_errorcode () {
+    return $1
+}
+
+doit() {
+    echo "Step 1: nothing out of the ordinary"
+    echo "Step 2: this is the last step you should see"
+    return_errorcode 2
+    echo "Step 3: if you can see this, something is wrong! (rc=$?)"
+}
+
+undo() {
+    echo "This doesn't really do anything."
+}
+
+${mash_action}

--- a/src/share/recipes/setup/golang-4dev.sh
+++ b/src/share/recipes/setup/golang-4dev.sh
@@ -14,7 +14,7 @@ get_latest_version() {
     _debug "Doing GET [$url] to obtain latest version..."
     # curl complains on bad output below but otherwise everything works ;)
     version=$(
-        curl -sX GET "$url" | head -5 |
+        curl -sSX GET "$url" | head -5 |
             awk '/"version": "go[0-9]+\.[0-9]+\.[0-9]+"/ {print substr($2, 4)}'
     )
     version=${version%*\",} # rstrip ",


### PR DESCRIPTION
Improve error handling

 - update curl usage to always invoke -S along with -s for verbosity
 - add 'set -e' usage to mash in order to exit if any command fails
 - new recipe fail used to test exiting on failure