### PR TITLE
Add removal library and refactor recipes to use it 

### DIFF
--- a/src/lib/removal.sh
+++ b/src/lib/removal.sh
@@ -6,8 +6,7 @@ import assert
 _rm_name_='removal.sh'
 
 _delete_file() {
-    if [ -e "$1" ]
-    then
+    if [ -e "$1" ]; then
         _debug "Removing $1.."
         rm "$1"
         rc=$? # saving rc for the error message
@@ -26,10 +25,9 @@ delete_files() {
         _info "$1"
     fi
     shift  # first argument must always be info string to print, the rest of the arguments are files
-    for var in "$@"
-    do
+    for var in "$@"; do
         _delete_file "$var"
-        failed=$(($failed + $?))
+        failed=$((failed + $?))
     done
     return "$failed"
 }

--- a/src/lib/removal.sh
+++ b/src/lib/removal.sh
@@ -22,7 +22,7 @@ _delete_file() {
 
 delete_files() {
     failed=0
-    if ! [ -z "$1" ]; then
+    if ! [ -z "$1" ]; then # skip printing the message if empty
         _info "$1"
     fi
     shift  # first argument must always be info string to print, the rest of the arguments are files
@@ -35,12 +35,11 @@ delete_files() {
 }
 
 delete_directory() {
-    if ! [ -z "$1" ]; then
+    if ! [ -z "$1" ]; then # skip printing the message if empty
         _info "$1"
     fi
     shift  # first argument must always be info string to print, the second is the directory
-    if [ -e "$1" ]
-    then
+    if [ -d "$1" ]; then
         _debug "Removing directory $1.."
         rm -r "$1"
         rc=$? # saving rc for the error message
@@ -49,7 +48,7 @@ delete_directory() {
             return 1
         fi
     else
-        _warn "Trying to remove directory $1 but it does not exist! Skipping."
+        _warn "Trying to remove directory $1 but it does not exist (or is a file)! Skipping."
     fi
 }
 
@@ -58,7 +57,7 @@ apt_remove() {
         _info "Removing $1..."
         sudo apt remove -y $1
     else
-        _warn "Attempting to remove package $1 but it was not installed! Skipping."
+        _warn "Attempting to remove package(s) $1 but they were not installed! Skipping."
     fi
 }
 
@@ -67,9 +66,8 @@ apt_purge() {
         _info "Purging $1..."
         sudo apt purge $1 # not using -y here because of issue #19
     else
-        _warn "Attempting to purge package $1 but it was not installed! Skipping."
+        _warn "Attempting to purge package(s) $1 but they were not installed! Skipping."
     fi
-
 }
 
 if [ "$_name_" = "$_rm_name_" ]; then

--- a/src/lib/removal.sh
+++ b/src/lib/removal.sh
@@ -1,0 +1,77 @@
+#! /bin/sh
+
+import logging
+import assert
+
+_rm_name_='removal.sh'
+
+_delete_file() {
+    if [ -e "$1" ]
+    then
+        _debug "Removing $1.."
+        rm "$1"
+        rc=$? # saving rc for the error message
+        if [ $rc -ne 0 ]; then
+            _error "'rm $1' failed! rc=$rc"
+            return 1
+        fi
+    else
+        _warn "Trying to remove $1 but it does not exist! Skipping."
+    fi
+}
+
+delete_files() {
+    failed=0
+    if ! [ -z "$1" ]; then
+        _info "$1"
+    fi
+    shift  # first argument must always be info string to print, the rest of the arguments are files
+    for var in "$@"
+    do
+        _delete_file "$var"
+        failed=$(($failed + $?))
+    done
+    return "$failed"
+}
+
+delete_directory() {
+    if ! [ -z "$1" ]; then
+        _info "$1"
+    fi
+    shift  # first argument must always be info string to print, the second is the directory
+    if [ -e "$1" ]
+    then
+        _debug "Removing directory $1.."
+        rm -r "$1"
+        rc=$? # saving rc for the error message
+        if [ $rc -ne 0 ]; then
+            _error "'rm -r $1' failed! rc=$rc"
+            return 1
+        fi
+    else
+        _warn "Trying to remove directory $1 but it does not exist! Skipping."
+    fi
+}
+
+apt_remove() {
+    if dpkg -s $1; then
+        _info "Removing $1..."
+        sudo apt remove -y $1
+    else
+        _warn "Attempting to remove package $1 but it was not installed! Skipping."
+    fi
+}
+
+apt_purge() {
+    if dpkg -s $1; then
+        _info "Purging $1..."
+        sudo apt purge $1 # not using -y here because of issue #19
+    else
+        _warn "Attempting to purge package $1 but it was not installed! Skipping."
+    fi
+
+}
+
+if [ "$_name_" = "$_rm_name_" ]; then
+    _error "$_rm_name_ is a library to be sourced, not executed."
+fi

--- a/src/lib/tests/test-removal.sh
+++ b/src/lib/tests/test-removal.sh
@@ -1,0 +1,63 @@
+#! /bin/sh
+
+import unittest/assert
+import removal
+
+test_delete_file() {
+    touch '/tmp/test-removal-0'
+    _delete_file '/tmp/test-removal-0'
+    assert_false [ -e '/tmp/test-removal-0' ]
+}
+
+test_delete_file_nonexistent() {
+    _delete_file '/tmp/test-removal-0'
+    assert_equal 0 $?
+}
+
+test_delete_files() {
+    touch '/tmp/test-removal-1'
+    touch '/tmp/test-removal-2'
+    touch '/tmp/test-removal-3'
+    delete_files '' '/tmp/test-removal-1' '/tmp/test-removal-2' '/tmp/test-removal-3'
+    assert_false [ -e '/tmp/test-removal-1' ]
+    assert_false [ -e '/tmp/test-removal-2' ]
+    assert_false [ -e '/tmp/test-removal-3' ]
+}
+
+test_delete_files_nonexistent() {
+    delete_files '' '/tmp/test-removal-nonexistent-1' '/tmp/test-removal-nonexistent-2' '/tmp/test-removal-nonexistent-3'
+    assert_equal 0 $?
+}
+
+test_delete_directory() {
+    mkdir /tmp/test-removal-dir-1
+    delete_directory '' '/tmp/test-removal-dir-1'
+}
+
+test_delete_directory_nonexistent() {
+    delete_directory '' '/tmp/test-removal-dir-nonexistent-1'
+}
+
+# TODO: Figure out what to do with these
+# IMPORTANT: the apt tests are (for now) suppressed:
+#   This is because they install an actual (albeit simple and tiny) package.
+#   In the case of apt_purge() there is a Y/N prompt.
+#   Use them at your own risk.
+
+__test_apt_remove() {
+    sudo apt install -y rolldice
+    apt_remove rolldice
+}
+
+__test_apt_remove_no_install() {
+    apt_remove rolldice
+}
+
+__test_apt_purge() {
+    sudo apt install -y rolldice
+    apt_purge rolldice
+}
+
+__test_apt_purge_no_install() {
+    apt_purge rolldice
+}

--- a/src/lib/tests/test-removal.sh
+++ b/src/lib/tests/test-removal.sh
@@ -41,7 +41,7 @@ test_delete_directory_nonexistent() {
 # TODO: Figure out what to do with these
 # IMPORTANT: the apt tests are (for now) suppressed:
 #   This is because they install an actual (albeit simple and tiny) package.
-#   In the case of apt_purge() there is a Y/N prompt.
+#   In the case of apt_purge() there is a Y/N prompt (because of issue #19).
 #   Use them at your own risk.
 
 __test_apt_remove() {

--- a/src/share/recipes/install/bitwarden.sh
+++ b/src/share/recipes/install/bitwarden.sh
@@ -5,6 +5,7 @@
 import os
 import logging
 import gh-download
+import removal
 
 #: Install Bitwarden
 
@@ -78,33 +79,41 @@ doit() {
     inform_user
 }
 
+#undo() {
+#    _info "** Un-installing bitwarden:"
+#
+#    result=''
+#
+#    # Remove gnome assets
+#    _info "Removing gnome assets..."
+#    rm -f "${_LOCAL}/opt/bitwarden/bitwarden-icon.png"
+#    result="${result}:$?"
+#    rm -f "${_LOCAL}/share/applications/com.bitwarden.desktop"
+#    result="${result}:$?"
+#
+#    # Remove symlink
+#    _info "Removing symlink..."
+#    rm -f "$_LOCAL/bin/bitwarden-desktop"
+#    result="${result}:$?"
+#
+#    # Remove app image file
+#    _info "Removing bitwarden app image..."
+#    rm -f "${app_fullpath}"
+#    result="${result}:$?"
+#
+#    if [ "$result" = ':0:0:0:0' ]; then
+#        _info "Successfully un-installed bitwarden."
+#    else
+#        _warn "Un-installed bitwarden with errors: codes ${result}"
+#    fi
+#}
+
 undo() {
-    _info "** Un-installing bitwarden:"
-
-    result=''
-
-    # Remove gnome assets
-    _info "Removing gnome assets..."
-    rm -f "${_LOCAL}/opt/bitwarden/bitwarden-icon.png"
-    result="${result}:$?"
-    rm -f "${_LOCAL}/share/applications/com.bitwarden.desktop"
-    result="${result}:$?"
-
-    # Remove symlink
-    _info "Removing symlink..."
-    rm -f "$_LOCAL/bin/bitwarden-desktop"
-    result="${result}:$?"
-
-    # Remove app image file
-    _info "Removing bitwarden app image..."
-    rm -f "${app_fullpath}"
-    result="${result}:$?"
-
-    if [ "$result" = ':0:0:0:0' ]; then
-        _info "Successfully un-installed bitwarden."
-    else
-        _warn "Un-installed bitwarden with errors: codes ${result}"
-    fi
+    _info "Removing bitwarden:"
+   delete_files 'Removing gnome assets...' "${_LOCAL}/opt/bitwarden/bitwarden-icon.png" "${_LOCAL}/share/applications/com.bitwarden.desktop"
+    delete_files 'Removing symlink...' "$_LOCAL/bin/bitwarden-desktop"
+    delete_files 'Removing bitwarden app image...' "${app_fullpath}"
+    _info "bitwarden removed successfully."
 }
 
 main() {

--- a/src/share/recipes/install/bitwarden.sh
+++ b/src/share/recipes/install/bitwarden.sh
@@ -79,38 +79,9 @@ doit() {
     inform_user
 }
 
-#undo() {
-#    _info "** Un-installing bitwarden:"
-#
-#    result=''
-#
-#    # Remove gnome assets
-#    _info "Removing gnome assets..."
-#    rm -f "${_LOCAL}/opt/bitwarden/bitwarden-icon.png"
-#    result="${result}:$?"
-#    rm -f "${_LOCAL}/share/applications/com.bitwarden.desktop"
-#    result="${result}:$?"
-#
-#    # Remove symlink
-#    _info "Removing symlink..."
-#    rm -f "$_LOCAL/bin/bitwarden-desktop"
-#    result="${result}:$?"
-#
-#    # Remove app image file
-#    _info "Removing bitwarden app image..."
-#    rm -f "${app_fullpath}"
-#    result="${result}:$?"
-#
-#    if [ "$result" = ':0:0:0:0' ]; then
-#        _info "Successfully un-installed bitwarden."
-#    else
-#        _warn "Un-installed bitwarden with errors: codes ${result}"
-#    fi
-#}
-
 undo() {
     _info "Removing bitwarden:"
-   delete_files 'Removing gnome assets...' "${_LOCAL}/opt/bitwarden/bitwarden-icon.png" "${_LOCAL}/share/applications/com.bitwarden.desktop"
+    delete_files 'Removing gnome assets...' "${_LOCAL}/opt/bitwarden/bitwarden-icon.png" "${_LOCAL}/share/applications/com.bitwarden.desktop"
     delete_files 'Removing symlink...' "$_LOCAL/bin/bitwarden-desktop"
     delete_files 'Removing bitwarden app image...' "${app_fullpath}"
     _info "bitwarden removed successfully."

--- a/src/share/recipes/install/dev-essentials.sh
+++ b/src/share/recipes/install/dev-essentials.sh
@@ -80,23 +80,20 @@ doit() {
 }
 
 undo() {
-    _info "** UN-installing dev-essentials..."
+    _info "Removing dev-essentials:"
+    delete_files "Removing p_sswdless sudo setup ${p_sswdless_sudo_fullpath}..." "${p_sswdless_sudo_fullpath}"
+    _info "Removing github-cli..."
+    mash undo install github-cli # TODO: Is this ok here?
+    for package in $apt_packages; do # TODO: Maybe remove all together and not one by one?
+        apt_purge package
+    done
 
-    _info "-- Removing p_sswdless sudo setup ${p_sswdless_sudo_fullpath}..."
-    sudo rm -f "${p_sswdless_sudo_fullpath}"
+#    TODO: ????
+#    # moving at the end trying to reduce the disastrous effect of 'apt-get purge'
+#    _info "-- Removing apt config ${apt_confd_fullpath}..."
+#    sudo rm -f "${apt_confd_fullpath}"
 
-    _info "-- Removing github-cli..."
-    mash install github-cli
-
-    _info "-- Purging apt packages (will ask - please say NO! :)..."
-    # Asking the user on purge, because of issue #19:
-    sudo apt-get purge ${apt_packages}
-
-    # moving at the end trying to reduce the disastrous effect of 'apt-get purge'
-    _info "-- Removing apt config ${apt_confd_fullpath}..."
-    sudo rm -f "${apt_confd_fullpath}"
-
-    _info "** dev-essentials removal successful."
+    _info "dev-essentials removed successfully."
 }
 
 $mash_action

--- a/src/share/recipes/install/dev-essentials.sh
+++ b/src/share/recipes/install/dev-essentials.sh
@@ -3,6 +3,7 @@
 # Assumming lib/libma.sh has been sourced already.
 
 import logging
+import removal
 
 apt_confd_file='95mash'
 apt_confd_fullpath="/etc/apt/apt.conf.d/${apt_confd_file}"
@@ -82,11 +83,8 @@ doit() {
 undo() {
     _info "Removing dev-essentials:"
     delete_files "Removing p_sswdless sudo setup ${p_sswdless_sudo_fullpath}..." "${p_sswdless_sudo_fullpath}"
-    _info "Removing github-cli..."
     mash undo install github-cli # TODO: Is this ok here?
-    for package in $apt_packages; do # TODO: Maybe remove all together and not one by one?
-        apt_purge package
-    done
+    apt_purge $apt_packages
 
 #    TODO: ????
 #    # moving at the end trying to reduce the disastrous effect of 'apt-get purge'

--- a/src/share/recipes/install/docker-compose.sh
+++ b/src/share/recipes/install/docker-compose.sh
@@ -63,10 +63,8 @@ doit() {
 }
 
 undo() {
-    _warn "Removing docker-compose ..."
-
-    _info "Removing binary from ${bin_loc}"
-    rm "${bin_loc}" || die 65 "Could not remove ${bin_loc}/${app_file} !"
+    _info "Removing docker-compose:"
+    delete_files "Removing binary from ${bin_loc}..." "${bin_loc}"
     _info "docker-compose removed successfully."
 }
 

--- a/src/share/recipes/install/docker-compose.sh
+++ b/src/share/recipes/install/docker-compose.sh
@@ -3,6 +3,7 @@
 import os
 import logging
 import gh-download
+import removal
 
 #: Install Docker Compose
 

--- a/src/share/recipes/install/font-jetbrains-mono.sh
+++ b/src/share/recipes/install/font-jetbrains-mono.sh
@@ -6,6 +6,7 @@
 # Requires: unzip
 
 import logging
+import removal
 
 _jbm__download_link='https://download.jetbrains.com/fonts/JetBrainsMono-2.242.zip'
 _jbm__filename='JetBrainsMono-2.242.zip'

--- a/src/share/recipes/install/font-jetbrains-mono.sh
+++ b/src/share/recipes/install/font-jetbrains-mono.sh
@@ -63,10 +63,9 @@ doit() {
 }
 
 undo() {
-    # Remove jetbrains-mono fonts directory
-    rm -rf "$_jbm__target_dir"
-    _warn "Removed JetBrains-mono font dir $_jbm__target_dir"
-    _info 'DONE.'
+    _info "Removing JetBrains Mono font family:"
+    delete_directory "Removing JetBrains-mono font dir $_jbm__target_dir" "$_jbm__target_dir"
+    _info "JetBrains Mono font family removed successfully."
 }
 
 $mash_action

--- a/src/share/recipes/install/github-cli.sh
+++ b/src/share/recipes/install/github-cli.sh
@@ -70,15 +70,10 @@ doit() {
 }
 
 undo() {
-    _warn "UNinstalling github-cli version=[$version]"
-
-    _info "Removing symlink $_LOCAL/bin/gh ..."
-    rm "$_LOCAL/bin/gh"
-
-    _info "Removing directory ${app_fullpath} ..."
-    rm -r "${app_fullpath}"
-
-    _info 'UNinstallation ended.'
+    _info "Removing github-cli version=[$version]:"
+    delete_files "Removing symlink $_LOCAL/bin/gh ..." "$_LOCAL/bin/gh"
+    delete_directory "Removing directory ${app_fullpath} ..." "${app_fullpath}"
+    _info "github-cli removed successfully."
 }
 
 main() {

--- a/src/share/recipes/install/github-cli.sh
+++ b/src/share/recipes/install/github-cli.sh
@@ -3,6 +3,7 @@
 import os
 import logging
 import gh-download
+import removal
 
 #: Install github cli
 

--- a/src/share/recipes/install/keepassxc.sh
+++ b/src/share/recipes/install/keepassxc.sh
@@ -78,36 +78,12 @@ doit() {
 }
 
 undo() {
-    _info "** Un-installing keepassxc:"
-
-    result=''
-
-    # Remove gnome assets
-    _info "Removing gnome assets..."
-    rm -f "${_LOCAL}/opt/keepassxc/keepassxc-icon.png"
-    result="${result}:$?"
-    rm -f "${_LOCAL}/share/applications/org.keepassxc.desktop"
-    result="${result}:$?"
-
-    # Remove symlink
-    _info "Removing symlink..."
-    rm -f "$_LOCAL/bin/keepassxc"
-    result="${result}:$?"
-
-    # Remove app image file
-    _info "Removing keepassxc app image..."
-    rm -f "${app_fullpath}"
-    result="${result}:$?"
-
-    # Remove the opt directory:
-    rmdir "$_LOCAL/opt/keepassxc"
-    result="${result}:$?"
-
-    if [ "$result" = ':0:0:0:0:0' ]; then
-        _info "Successfully un-installed keepassxc."
-    else
-        _warn "Un-installed keepassxc with errors: codes ${result}"
-    fi
+    _info "Removing keepassxc:"
+    delete_files "Removing gnome assets..." "${_LOCAL}/opt/keepassxc/keepassxc-icon.png" "${_LOCAL}/share/applications/org.keepassxc.desktop"
+    delete_files "Removing symlink..." "$_LOCAL/bin/keepassxc"
+    delete_files "Removing keepassxc app image..." "${app_fullpath}"
+    delete_directory "Removing the opt directory..." "$_LOCAL/opt/keepassxc"
+    _info "keepassxc removed successfully."
 }
 
 main() {

--- a/src/share/recipes/install/keepassxc.sh
+++ b/src/share/recipes/install/keepassxc.sh
@@ -8,6 +8,7 @@
 import os
 import logging
 import gh-download
+import removal
 
 #: Download the app image
 download_appimage() {

--- a/src/share/recipes/install/pipx-local.sh
+++ b/src/share/recipes/install/pipx-local.sh
@@ -5,6 +5,7 @@ _PYTHON_VENVS="$_LOCAL/venvs"
 bashrcd_script='32-pipx-setup.sh'
 
 import logging
+import removal
 
 create_venvs_dir() {
     #:  Create `~/.local/venvs`

--- a/src/share/recipes/install/pipx-local.sh
+++ b/src/share/recipes/install/pipx-local.sh
@@ -108,17 +108,10 @@ doit() {
 }
 
 undo() {
-    _warn "Removing pipx-local:"
-
-    _info "Removing bashrcd script: ${bashrcd_script} ..."
-    rm -f "${bashrcd_script_path}"
-
-    _info "Removing symlink $_LOCAL/bin/pipx ..."
-    rm -f "$_LOCAL/bin/pipx"
-
-    _info "Removing pipx venv ..."
-    rm -rf "$_PYTHON_VENVS/pipx"
-
+    _info "Removing pipx-local:"
+    delete_files "Removing bashrcd script: ${bashrcd_script} ..." "${bashrcd_script_path}"
+    delete_files "Removing symlink $_LOCAL/bin/pipx ..." "$_LOCAL/bin/pipx"
+    delete_directory "Removing pipx venv ..." "$_PYTHON_VENVS/pipx"
     _info 'pipx-local removed successfully.'
 }
 

--- a/src/share/recipes/install/pycharm-community.sh
+++ b/src/share/recipes/install/pycharm-community.sh
@@ -6,6 +6,7 @@
 # Assumming lib/libma.sh has been sourced already.
 
 import logging
+import removal
 
 version='2021.2.3'
 flavor='community'

--- a/src/share/recipes/install/pycharm-community.sh
+++ b/src/share/recipes/install/pycharm-community.sh
@@ -133,31 +133,19 @@ doit() {
 }
 
 undo() {
-    _warn "UNinstalling pycharm version=[$version], flavor=${flavor}"
 
-    _info "Removing $HOME/.bashrc.d/42-pycharm-${flavor}.sh..."
-    rm "$HOME/.bashrc.d/42-pycharm-${flavor}.sh" ||
-        _warn "Could NOT remove add-to-path file $HOME/.bashrc.d/42-pycharm-${flavor}.sh!"
-
-    _info "Removing $_LOCAL/opt/pycharm-${flavor} symlink..."
-    rm -f "$_LOCAL/opt/pycharm-${flavor}" ||
-        _warn "Could NOT remove symlink $_LOCAL/opt/pycharm-${flavor}!"
-
-    dot_desktop_fullpath="$_LOCAL/share/applications/${dot_desktop_file_dst}"
-    _info "Removing dot-desktop ${dot_desktop_fullpath} ..."
-    rm "${dot_desktop_fullpath}"
-
-    _info "Removing $pycharm_dir..."
-    rm -r "$pycharm_dir" ||
-        _warn "Could NOT remove directory $pycharm_dir!"
-    # TODO: remove the .desktop file
+    _info "Removing pycharm version=[$version], flavor=${flavor}:"
+    delete_files "Removing $HOME/.bashrc.d/42-pycharm-${flavor}.sh..." "$HOME/.bashrc.d/42-pycharm-${flavor}.sh"
+    delete_files "Removing $_LOCAL/opt/pycharm-${flavor} symlink..." "$_LOCAL/opt/pycharm-${flavor}"
+    delete_files "Removing dot-desktop $_LOCAL/share/applications/${dot_desktop_file_dst} ..." "$_LOCAL/share/applications/${dot_desktop_file_dst}"
+    delete_directory "Removing $pycharm_dir..." "$pycharm_dir"
     cat << EOS
 
 In order to have all your terminals know about the add-to-path change,
 you need to close (and re-open) all open terminals, OR log out, then log
 back in.
 
-UN-installation ended.
+pycharm removed successfully.
 
 EOS
 }

--- a/src/share/recipes/install/shell-check.sh
+++ b/src/share/recipes/install/shell-check.sh
@@ -66,15 +66,10 @@ doit() {
 }
 
 undo() {
-    _warn "UNinstalling shellcheck version=[$version]"
-
-    _info "Removing symlink $_LOCAL/bin/shellcheck ..."
-    rm "$_LOCAL/bin/shellcheck"
-
-    _info "Removing directory ${app_fullpath} ..."
-    rm -r "${app_fullpath}"
-
-    _info 'UNinstallation ended.'
+    _info "Removing shellcheck version=[$version]:"
+    delete_files "Removing symlink $_LOCAL/bin/shellcheck ..." "$_LOCAL/bin/shellcheck"
+    delete_directory "Removing directory ${app_fullpath} ..." "${app_fullpath}"
+    _info 'shellcheck removed successfully.'
 }
 
 main() {

--- a/src/share/recipes/install/shell-check.sh
+++ b/src/share/recipes/install/shell-check.sh
@@ -3,6 +3,7 @@
 import os
 import logging
 import gh-download
+import removal
 
 #: Install shellcheck
 

--- a/src/share/recipes/install/shfmt.sh
+++ b/src/share/recipes/install/shfmt.sh
@@ -3,6 +3,7 @@
 import os
 import logging
 import gh-download
+import removal
 
 #: Install shfmt
 
@@ -70,21 +71,20 @@ doit() {
 }
 
 undo() {
-    _warn "Removing shfmt version=[$version]"
-    _info "Removing symlink $_LOCAL/bin/shfmt ..."
-    rm "$_LOCAL/bin/shfmt"
+    _info "Removing shfmt version=[$version]:"
+    delete_files "Removing symlink $_LOCAL/bin/shfmt ..." "$_LOCAL/bin/shfmt"
+    delete_files "Removing shfmt binary ..." "${app_fullpath}/${app_file}"
 
-    _info "Removing shfmt binary ..."
-    rm "${app_fullpath}/${app_file}"
-
-    if [ -d "${app_fullpath}" ]; then
-        _info "Removing directory ${app_fullpath} ..."
-        rmdir "${app_fullpath}"
-        [ -d "${app_fullpath}" ] &&
-            _warn "shfmt directory not empty, so not deleted: ${app_fullpath}"
-    else
-        _info "Directory already removed: ${app_fullpath}."
-    fi
+    # TODO: the previous logic deleted the directory only if empty, the new one deletes regardless
+    delete_directory "Removing directory ${app_fullpath} ..." "${app_fullpath}"
+#    if [ -d "${app_fullpath}" ]; then
+#        _info "Removing directory ${app_fullpath} ..."
+#        rmdir "${app_fullpath}"
+#        [ -d "${app_fullpath}" ] &&
+#            _warn "shfmt directory not empty, so not deleted: ${app_fullpath}"
+#    else
+#        _info "Directory already removed: ${app_fullpath}."
+#    fi
     _info 'shfmt removed successfully.'
 }
 

--- a/src/share/recipes/install/slack.sh
+++ b/src/share/recipes/install/slack.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 import os
+import removal
 
 case "$_OS_ARCH" in
 x86_64)
@@ -57,9 +58,9 @@ doit() {
 }
 
 undo() {
-    _warn "Removing slack-desktop .deb file..."
-    sudo apt-get remove -y slack-desktop
-    _info 'DONE.'
+    _info "Removing slack-desktop:"
+    apt_remove slack-desktop
+    _info 'slack-desktop removed successfully.'
 }
 
 # shellcheck disable=SC2154

--- a/src/share/recipes/install/vscodium.sh
+++ b/src/share/recipes/install/vscodium.sh
@@ -5,6 +5,7 @@
 import os
 import logging
 import gh-download
+import removal
 
 #: Install VSCodium
 
@@ -86,12 +87,12 @@ doit() {
 }
 
 undo() {
-    _info "*UN*installing codium v${version} ($arch_short)..."
-    rm "${_LOCAL}/bin/codium" || die 15 "Cannot remove ${_LOCAL}/bin/codium"
-    rm -r "${_LOCAL}/opt/${app_opt_dirname}" || die 15 "Cannot remove ${_LOCAL}/opt/${app_opt_dirname}"
-    rm "${_LOCAL}/share/applications/${dot_desktop_file}"
+    _info "Removing codium v${version} ($arch_short):"
+    delete_files "" "${_LOCAL}/bin/codium"
+    delete_directory "" "${_LOCAL}/opt/${app_opt_dirname}"
+    delete_files "" "${_LOCAL}/share/applications/${dot_desktop_file}"
     smoke_test && die 99 "Coduim NOT removed, still working"
-    echo 'Undo install done.'
+    _info 'codium removed successfully.'
 }
 
 get_arch_short() {

--- a/src/share/recipes/install/wire.sh
+++ b/src/share/recipes/install/wire.sh
@@ -4,7 +4,8 @@
 
 import logging
 import gh-download
-# Assumming lib/libma.sh has been sourced already.
+import removal
+# Assumming lib/libma.sh has been sourced already. # those functions are now in os and string in the stdlib
 
 _ARCH=x86_64
 
@@ -82,32 +83,12 @@ doit() {
 }
 
 undo() {
-    _info "** Un-installing Wire:"
-
-    local result=''
-
-    # Remove gnome assets
-    _info "Removing gnome assets..."
-    # rm -f "${_ICONS_DIR}/${icon_file}"
-    result="${result}:$?"
-    rm -f "${_LOCAL}/share/applications/appimagekit-wire-desktop.desktop"
-    result="${result}:$?"
-
-    # Remove symlink
-    _info "Removing symlink..."
-    rm -f "$_LOCAL/bin/wire-desktop"
-    result="${result}:$?"
-
-    # Remove app image file
-    _info "Removing wire app image..."
-    rm -f "${app_fullpath}"
-    result="${result}:$?"
-
-    if [ "$result" = ':0:0:0:0' ]; then
-        _info "Successfully un-installed wire."
-    else
-        _warn "Un-installed wire with errors: codes [${result}]"
-    fi
+    _info "Removing wire:"
+    # rm -f "${_ICONS_DIR}/${icon_file}" # this was commented in the old implementation
+    delete_files "Removing gnome assets..." "${_LOCAL}/share/applications/appimagekit-wire-desktop.desktop"
+    delete_files "Removing symlink..." "$_LOCAL/bin/wire-desktop"
+    delete_files "Removing wire app image..." "${app_fullpath}"
+    _info 'wire removed successfully.'
 }
 
 main() {

--- a/src/share/recipes/setup/fail.sh
+++ b/src/share/recipes/setup/fail.sh
@@ -13,7 +13,7 @@ doit() {
 }
 
 undo() {
-    echo "This doesn't really do anything."
+    echo "This is a test recipe, nothing to undo."
 }
 
 ${mash_action}

--- a/src/share/recipes/setup/python-dev.sh
+++ b/src/share/recipes/setup/python-dev.sh
@@ -1,7 +1,8 @@
 #! /bin/sh
 
 import logging
-# Assumming lib/libma.sh has been sourced already.
+import removal
+# Assumming lib/libma.sh has been sourced already. # those functions are now in os and string in the stdlib
 
 link_path="$_LOCAL/bin/python"
 
@@ -56,23 +57,12 @@ doit() {
 }
 
 undo() {
-    if ! [ -e "${link_path}" ]; then
-        _warn "Link '~/.local/bin/python' python3 not there, skipping."
-    else
-        _info "Removing '~/.local/bin/python' link to python3..."
-        rm "${link_path}"
-        [ -e "${link_path}" ] && die 14 "Removing ${link_path} FAILED!"
-    fi
-
+    _info "Removing python-dev:"
+    delete_files "Removing '~/.local/bin/python' link to python3..." "${link_path}"
     _info "NOT Removing dev-essentials (see #19)."
-    # mash undo install dev-essentials
-
-    _info "Purging apt packages..."
-    sudo apt-get purge ${_apt_packages}
-
-    _info "Removing pipx-local..."
+    # mash undo install dev-essentials # TODO: should this still be the case?
+    apt_purge $_apt_packages
     mash undo install pipx-local
-
     _info "python-dev removed successfully."
 }
 


### PR DESCRIPTION
Add removal library and modify some recipes to use it #23

Most recipes seem to work with the removal library
The following were not properly tested because of failing installation (in a headless chroot):
 - font-jetbrains-mono
 - pipx-local
 - pycharm-community
 - slack